### PR TITLE
Replace removed images with SVG placeholders

### DIFF
--- a/public/assets/README.md
+++ b/public/assets/README.md
@@ -1,0 +1,5 @@
+# Assets Placeholders
+
+The original `boxing.png` and `hug.png` files were removed from version control.
+These simple SVG placeholders are provided to maintain references until proper
+images can be added.

--- a/public/assets/boxing.svg
+++ b/public/assets/boxing.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="14" fill="#333">boxing</text>
+</svg>

--- a/public/assets/hug.svg
+++ b/public/assets/hug.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="14" fill="#333">hug</text>
+</svg>


### PR DESCRIPTION
## Summary
- Replace `boxing.png` and `hug.png` with lightweight SVG placeholders.
- Document removed assets for future image uploads.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2a25282c832ea4cd27112efa14a6