### PR TITLE
Handle Supabase errors in room API and add tests

### DIFF
--- a/app/api/room/route.ts
+++ b/app/api/room/route.ts
@@ -7,22 +7,35 @@ export async function POST(req: NextRequest) {
   const { code } = await req.json();
   const roomCode = (code || randomBytes(3).toString('hex')).toLowerCase();
 
-  let { data: room } = await adminClient
+  const { data: roomData, error } = await adminClient
     .from('rooms')
     .select('id')
     .eq('code', roomCode)
     .single();
+  if (error) {
+    console.error(error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
 
+  let room = roomData;
   if (!room) {
-    const { data } = await adminClient
+    const { data, error: insertError } = await adminClient
       .from('rooms')
       .insert({ code: roomCode })
       .select('id')
       .single();
+    if (insertError) {
+      console.error(insertError);
+      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    }
     room = data!;
-    await adminClient
+    const { error: statusError } = await adminClient
       .from('status')
       .insert({ room_id: room.id, your_ready: false, their_ready: false });
+    if (statusError) {
+      console.error(statusError);
+      return NextResponse.json({ error: statusError.message }, { status: 500 });
+    }
   }
 
   const roomToken = signRoomToken(room.id);

--- a/tests/roomRoute.test.ts
+++ b/tests/roomRoute.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+describe.sequential('POST /api/room error handling', () => {
+  test('returns 500 when room select fails', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/supabase', () => ({
+      adminClient: {
+        from: (table: string) => {
+          if (table === 'rooms') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  single: async () => ({ data: null, error: { message: 'select fail' } }),
+                }),
+              }),
+            };
+          }
+          if (table === 'status') {
+            return {
+              insert: async () => ({ error: { message: 'status fail' } }),
+            };
+          }
+          throw new Error('unexpected table ' + table);
+        },
+      },
+    }));
+    vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
+
+    const { POST } = await import('../app/api/room/route');
+    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'select fail' });
+  });
+
+  test('returns 500 when room insert fails', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/supabase', () => {
+      let roomsCall = 0;
+      return {
+        adminClient: {
+          from: (table: string) => {
+            if (table === 'rooms') {
+              if (roomsCall === 0) {
+                roomsCall++;
+                return {
+                  select: () => ({
+                    eq: () => ({
+                      single: async () => ({ data: null, error: null }),
+                    }),
+                  }),
+                };
+              }
+              return {
+                insert: () => ({
+                  select: () => ({
+                    single: async () => ({ data: null, error: { message: 'insert fail' } }),
+                  }),
+                }),
+              };
+            }
+            if (table === 'status') {
+              return {
+                insert: async () => ({ error: { message: 'should not call' } }),
+              };
+            }
+            throw new Error('unexpected table ' + table);
+          },
+        },
+      };
+    });
+    vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
+
+    const { POST } = await import('../app/api/room/route');
+    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'insert fail' });
+  });
+
+  test('returns 500 when status insert fails', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/supabase', () => {
+      let roomsCall = 0;
+      return {
+        adminClient: {
+          from: (table: string) => {
+            if (table === 'rooms') {
+              if (roomsCall === 0) {
+                roomsCall++;
+                return {
+                  select: () => ({
+                    eq: () => ({
+                      single: async () => ({ data: null, error: null }),
+                    }),
+                  }),
+                };
+              }
+              return {
+                insert: () => ({
+                  select: () => ({
+                    single: async () => ({ data: { id: '1' }, error: null }),
+                  }),
+                }),
+              };
+            }
+            if (table === 'status') {
+              return {
+                insert: async () => ({ error: { message: 'status fail' } }),
+              };
+            }
+            throw new Error('unexpected table ' + table);
+          },
+        },
+      };
+    });
+    vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
+
+    const { POST } = await import('../app/api/room/route');
+    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'status fail' });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
 
 export default defineConfig({
   test: {
     environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
   },
   css: {
     postcss: {


### PR DESCRIPTION
## Summary
- return 500 with error message when Supabase queries fail in room API
- configure vitest alias and add tests for Supabase failures

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc6ddf36ac832e9ae4ab2ad3f8fe92