### PR TITLE
Handle missing room lookups gracefully

### DIFF
--- a/app/api/room/route.ts
+++ b/app/api/room/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: NextRequest) {
     .from('rooms')
     .select('id')
     .eq('code', roomCode)
-    .single();
+    .maybeSingle();
   if (error) {
     console.error(error);
     return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
## Summary
- Use `maybeSingle` when checking for existing rooms so missing rooms don't raise errors
- Update room route tests to mock `maybeSingle`
- Add test verifying that a missing room is inserted without 500

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc7163dfc8832ea0a1c9824c2cdde0