### PR TITLE
Add env example and guard Supabase configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_SUPABASE_URL=your-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role
+GOOGLE_API_KEY=your-gemini-key
+ROOM_JWT_SECRET=super-secret-string

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ with check (room_id = auth.jwt() ->> 'room_id');
 Create an API key at [Google AI Studio](https://aistudio.google.com) and set `GOOGLE_API_KEY`.
 
 ### 4. Environment variables
-Create `.env.local`:
+Copy `.env.example` to `.env.local` and fill in your keys:
 ```
 NEXT_PUBLIC_SUPABASE_URL=your-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,8 +1,14 @@
 import { createClient } from '@supabase/supabase-js';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !anonKey || !serviceRoleKey) {
+  throw new Error(
+    'Missing Supabase environment variables. Check NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY and SUPABASE_SERVICE_ROLE_KEY.'
+  );
+}
 
 export const createBrowserClient = (token?: string) =>
   createClient(url, anonKey, {


### PR DESCRIPTION
## Summary
- improve Supabase client initialization by explicitly checking required environment variables
- document required environment keys and provide `.env.example`
- allow `.env.example` to be committed

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb38e7878832eb2b0442cb573dfaf