### PR TITLE
Isolate Supabase admin client from client bundle

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { adminClient } from '@/lib/supabase';
+import { createAdminClient } from '@/lib/supabase';
 import { verifyRoomToken } from '@/lib/roomToken';
 import { callGemini, parseGeminiResponse } from '@/lib/gemini';
 
@@ -14,6 +14,8 @@ export async function POST(req: NextRequest) {
   if (Date.now() - last < 10_000)
     return NextResponse.json({ error: 'rate limited' }, { status: 429 });
   lastGen.set(roomId, Date.now());
+
+  const adminClient = createAdminClient();
 
   const { data: entries } = await adminClient
     .from('entries')

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { adminClient } from '@/lib/supabase';
+import { createAdminClient } from '@/lib/supabase';
 import { verifyRoomToken } from '@/lib/roomToken';
 
 export async function GET(req: NextRequest) {
@@ -8,6 +8,7 @@ export async function GET(req: NextRequest) {
   const limit = Number(searchParams.get('limit') || '20');
   const roomId = verifyRoomToken(roomToken);
   if (!roomId) return NextResponse.json({ error: 'invalid token' }, { status: 401 });
+  const adminClient = createAdminClient();
 
   const { data } = await adminClient
     .from('summaries')

--- a/app/api/room/route.ts
+++ b/app/api/room/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { adminClient } from '@/lib/supabase';
+import { createAdminClient } from '@/lib/supabase';
 import { signRoomToken } from '@/lib/roomToken';
 import { randomBytes } from 'crypto';
 
 export async function POST(req: NextRequest) {
   const { code } = await req.json();
   const roomCode = (code || randomBytes(3).toString('hex')).toLowerCase();
+  const adminClient = createAdminClient();
 
   const { data: roomData, error } = await adminClient
     .from('rooms')

--- a/app/api/submit/route.ts
+++ b/app/api/submit/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { adminClient } from '@/lib/supabase';
+import { createAdminClient } from '@/lib/supabase';
 import { verifyRoomToken } from '@/lib/roomToken';
 
 export async function POST(req: NextRequest) {
   const { roomToken, side, content } = await req.json();
   const roomId = verifyRoomToken(roomToken);
   if (!roomId) return NextResponse.json({ error: 'invalid token' }, { status: 401 });
+  const adminClient = createAdminClient();
 
   await adminClient.from('entries').insert({ room_id: roomId, side, content });
   await adminClient

--- a/app/api/thumb/route.ts
+++ b/app/api/thumb/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { adminClient } from '@/lib/supabase';
+import { createAdminClient } from '@/lib/supabase';
 import { verifyRoomToken } from '@/lib/roomToken';
 
 export async function POST(req: NextRequest) {
   const { roomToken, which, value } = await req.json();
   const roomId = verifyRoomToken(roomToken);
   if (!roomId) return NextResponse.json({ error: 'invalid token' }, { status: 401 });
+  const adminClient = createAdminClient();
 
   const { data: summary } = await adminClient
     .from('summaries')

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -2,7 +2,6 @@ import { createClient } from '@supabase/supabase-js';
 
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 export const createBrowserClient = (token?: string) =>
   createClient(url, anonKey, {
@@ -10,6 +9,10 @@ export const createBrowserClient = (token?: string) =>
     global: { headers: token ? { Authorization: `Bearer ${token}` } : {} },
   });
 
-export const adminClient = createClient(url, serviceRoleKey, {
-  auth: { persistSession: false },
-});
+// Lazily create the admin client so that this module can be imported in the
+// browser without trying to access the service role key, which should remain
+// server-side only.
+export const createAdminClient = () =>
+  createClient(url, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
+    auth: { persistSession: false },
+  });

--- a/tests/roomRoute.test.ts
+++ b/tests/roomRoute.test.ts
@@ -5,7 +5,7 @@ describe.sequential('POST /api/room error handling', () => {
   test('returns 500 when room select fails', async () => {
     vi.resetModules();
     vi.doMock('@/lib/supabase', () => ({
-      adminClient: {
+      createAdminClient: () => ({
         from: (table: string) => {
           if (table === 'rooms') {
             return {
@@ -23,7 +23,7 @@ describe.sequential('POST /api/room error handling', () => {
           }
           throw new Error('unexpected table ' + table);
         },
-      },
+      }),
     }));
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
 
@@ -39,7 +39,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/supabase', () => {
       let roomsCall = 0;
       return {
-        adminClient: {
+        createAdminClient: () => ({
           from: (table: string) => {
             if (table === 'rooms') {
               if (roomsCall === 0) {
@@ -67,7 +67,7 @@ describe.sequential('POST /api/room error handling', () => {
             }
             throw new Error('unexpected table ' + table);
           },
-        },
+        }),
       };
     });
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
@@ -84,7 +84,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/supabase', () => {
       let roomsCall = 0;
       return {
-        adminClient: {
+        createAdminClient: () => ({
           from: (table: string) => {
             if (table === 'rooms') {
               if (roomsCall === 0) {
@@ -112,7 +112,7 @@ describe.sequential('POST /api/room error handling', () => {
             }
             throw new Error('unexpected table ' + table);
           },
-        },
+        }),
       };
     });
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
@@ -129,7 +129,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/supabase', () => {
       let roomsCall = 0;
       return {
-        adminClient: {
+        createAdminClient: () => ({
           from: (table: string) => {
             if (table === 'rooms') {
               if (roomsCall === 0) {
@@ -157,7 +157,7 @@ describe.sequential('POST /api/room error handling', () => {
             }
             throw new Error('unexpected table ' + table);
           },
-        },
+        }),
       };
     });
     const signRoomToken = vi.fn(() => 'token');
@@ -176,7 +176,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/supabase', () => {
       let roomsCall = 0;
       return {
-        adminClient: {
+        createAdminClient: () => ({
           from: (table: string) => {
             if (table === 'rooms') {
               if (roomsCall === 0) {
@@ -207,7 +207,7 @@ describe.sequential('POST /api/room error handling', () => {
             }
             throw new Error('unexpected table ' + table);
           },
-        },
+        }),
       };
     });
     const signRoomToken = vi.fn(() => 'token');


### PR DESCRIPTION
## Summary
- Lazily create Supabase admin client to avoid requiring service role key in browser
- Update API routes to call `createAdminClient` per request
- Adjust tests for new admin client factory

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcb45bddbc832e85abbc900b998eab