### PR TITLE
Handle missing Gemini key with fallback summary

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase';
 import { verifyRoomToken } from '@/lib/roomToken';
-import { callGemini, parseGeminiResponse } from '@/lib/gemini';
+import { callGemini, parseGeminiResponse, type GeminiSummary } from '@/lib/gemini';
 
 const lastGen = new Map<string, number>();
 
@@ -25,8 +25,20 @@ export async function POST(req: NextRequest) {
   const your = entries?.find((e) => e.side === 'your')?.content || '';
   const their = entries?.find((e) => e.side === 'their')?.content || '';
 
-  const text = await callGemini(your, their);
-  const summary = parseGeminiResponse(text);
+  let summary: GeminiSummary;
+  if (!process.env.GOOGLE_API_KEY) {
+    summary = { summary: 'Missing Google API key', nextSteps: [], toneNotes: '' };
+  } else {
+    try {
+      const text = await callGemini(your, their);
+      summary = parseGeminiResponse(text);
+    } catch (err) {
+      return NextResponse.json(
+        { error: 'Failed to generate summary' },
+        { status: 500 }
+      );
+    }
+  }
 
   if (save) {
     await adminClient.from('summaries').insert({ room_id: roomId, content: JSON.stringify(summary) });


### PR DESCRIPTION
## Summary
- guard summary generation when the Google API key is missing
- return a JSON error instead of crashing if Gemini calls fail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcb9860a74832e9b3fa87550d3bf1a