### PR TITLE
Gracefully handle missing Gemini API key

### DIFF
--- a/lib/gemini.ts
+++ b/lib/gemini.ts
@@ -10,9 +10,18 @@ const schema = z.object({
 export type GeminiSummary = z.infer<typeof schema>;
 
 export async function callGemini(your: string, their: string): Promise<string> {
-  const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY!);
+  const apiKey = process.env.GOOGLE_API_KEY;
+  if (!apiKey) {
+    return JSON.stringify({
+      summary: `Your Side: ${your}\nTheir Side: ${their}`,
+      nextSteps: [],
+      toneNotes: '',
+    });
+  }
+  const genAI = new GoogleGenerativeAI(apiKey);
   const model = genAI.getGenerativeModel({ model: 'gemini-2.5-pro' });
-  const system = 'You are a neutral mediator. Summarize both sides fairly. Use validating, non-judgmental language. Offer 2–3 practical next steps phrased as “We can…” and acknowledge feelings. Avoid taking sides; avoid blame.';
+  const system =
+    'You are a neutral mediator. Summarize both sides fairly. Use validating, non-judgmental language. Offer 2–3 practical next steps phrased as “We can…” and acknowledge feelings. Avoid taking sides; avoid blame.';
   const user = `Your Side:\n${your}\n\nTheir Side:\n${their}`;
   const result = await model.generateContent({
     contents: [

--- a/tests/generateRoute.test.ts
+++ b/tests/generateRoute.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+describe('POST /api/generate', () => {
+  test('returns summary when GOOGLE_API_KEY is missing', async () => {
+    vi.resetModules();
+    delete process.env.GOOGLE_API_KEY;
+    vi.doMock('@/lib/supabase', () => ({
+      createAdminClient: () => ({
+        from: (table: string) => {
+          if (table === 'entries') {
+            return {
+              select: () => ({
+                eq: async () => ({
+                  data: [
+                    { side: 'your', content: 'your perspective' },
+                    { side: 'their', content: 'their perspective' },
+                  ],
+                }),
+              }),
+            };
+          }
+          if (table === 'summaries') {
+            return {
+              insert: async () => ({ error: null }),
+            };
+          }
+          throw new Error('unexpected table ' + table);
+        },
+      }),
+    }));
+    vi.doMock('@/lib/roomToken', () => ({ verifyRoomToken: () => 'room1' }));
+
+    const { POST } = await import('../app/api/generate/route');
+    const req = {
+      json: async () => ({ roomToken: 't', save: false }),
+    } as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.summary).toContain('your perspective');
+    expect(data.summary).toContain('their perspective');
+    expect(data.nextSteps).toEqual([]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add local fallback in `callGemini` when `GOOGLE_API_KEY` isn't set
- wrap `/api/generate` logic in try/catch to surface generation errors
- cover generate route behavior without API key

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcbb0d8e24832e91da97220a779861