### PR TITLE
fix(roomToken): assert ROOM_JWT_SECRET when signing

### DIFF
--- a/lib/roomToken.ts
+++ b/lib/roomToken.ts
@@ -9,7 +9,7 @@ if (!secret) {
 }
 
 export function signRoomToken(roomId: string): string {
-  return jwt.sign({ room_id: roomId }, secret, { expiresIn: "7d" });
+  return jwt.sign({ room_id: roomId }, secret!, { expiresIn: "7d" });
 }
 
 export function verifyRoomToken(token: string): string | null {


### PR DESCRIPTION
## Summary
- assert `ROOM_JWT_SECRET` when signing room tokens to satisfy TypeScript

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected 'Missing Google API key' to contain 'your perspective')*


------
https://chatgpt.com/codex/tasks/task_e_68bd9809d3b4832eb2035eb3acc40cc2