### PR TITLE
Ensure room token secret typed for JWT verification

### DIFF
--- a/lib/roomToken.ts
+++ b/lib/roomToken.ts
@@ -14,7 +14,7 @@ export function signRoomToken(roomId: string): string {
 
 export function verifyRoomToken(token: string): string | null {
   try {
-    const payload = jwt.verify(token, secret) as jwt.JwtPayload & {
+    const payload = jwt.verify(token, secret!) as jwt.JwtPayload & {
       room_id?: string;
     };
     return payload.room_id ?? null;


### PR DESCRIPTION
## Summary
- assert the room secret when verifying JWTs so TypeScript knows it is defined

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected 'your perspective', received 'Missing Google API key')*
- `pnpm build` *(fails: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9ad44fbc832e9125c8150f65a5f4