### PR TITLE
Broadcast generated summaries to both room participants

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -50,6 +50,18 @@ export async function POST(req: NextRequest) {
       summary = parseGeminiResponse(text);
     }
 
+    const { data: room } = await adminClient
+      .from("rooms")
+      .select("code")
+      .eq("id", roomId)
+      .single();
+
+    if (room?.code) {
+      adminClient
+        .channel(`room-${room.code}`)
+        .send({ type: "broadcast", event: "SUMMARY", payload: summary });
+    }
+
     return NextResponse.json(summary);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "unknown error";

--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -34,6 +34,11 @@ export default function RoomPage({ params }: { params: { code: string } }) {
         if (payload.who === 'your') setYourReady(payload.ready);
         if (payload.who === 'their') setTheirReady(payload.ready);
       })
+      .on('broadcast', { event: 'SUMMARY' }, ({ payload }) => {
+        setSummary(payload as GeminiSummary);
+        setYourReady(false);
+        setTheirReady(false);
+      })
       .subscribe();
     return () => {
       client.removeChannel(channel);

--- a/tests/generateRoute.test.ts
+++ b/tests/generateRoute.test.ts
@@ -20,8 +20,18 @@ describe('POST /api/generate', () => {
               }),
             };
           }
+          if (table === 'rooms') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  single: async () => ({ data: { code: 'abc' } }),
+                }),
+              }),
+            };
+          }
           throw new Error('unexpected table ' + table);
         },
+        channel: () => ({ send: vi.fn() }),
       }),
     }));
     vi.doMock('@/lib/roomToken', () => ({ verifyRoomToken: () => 'room1' }));


### PR DESCRIPTION
## Summary
- broadcast generated summary over the room channel so everyone receives it
- listen for `SUMMARY` events on the room page to update both users and reset readiness
- adjust tests for the new broadcast behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb0be11ec832e823db3a0590f4f24