### PR TITLE
feat: add name input and side assignment

### DIFF
--- a/app/api/room/route.ts
+++ b/app/api/room/route.ts
@@ -4,7 +4,7 @@ import { signRoomToken } from '@/lib/roomToken';
 import { randomBytes } from 'crypto';
 
 export async function POST(req: NextRequest) {
-  const { code } = await req.json();
+  const { code, name } = await req.json();
   const roomCode = (code || randomBytes(3).toString('hex')).toLowerCase();
   const adminClient = createAdminClient();
 
@@ -40,5 +40,6 @@ export async function POST(req: NextRequest) {
   }
 
   const roomToken = signRoomToken(room.id);
-  return NextResponse.json({ roomId: room.id, roomToken, code: roomCode });
+  const side = Math.random() < 0.5 ? 'your' : 'their';
+  return NextResponse.json({ roomId: room.id, roomToken, code: roomCode, side });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 
 export default function Home() {
   const [code, setCode] = useState('');
+  const [name, setName] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
@@ -14,10 +15,12 @@ export default function Home() {
       const res = await fetch('/api/room', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code: roomCode }),
+        body: JSON.stringify({ code: roomCode, name }),
       });
       const data = await res.json();
       localStorage.setItem(`room-token-${roomCode}`, data.roomToken);
+      localStorage.setItem(`room-side-${roomCode}`, data.side);
+      if (name) localStorage.setItem(`room-name-${roomCode}`, name);
       router.push(`/room/${roomCode}`);
     } finally {
       setIsLoading(false);
@@ -28,6 +31,12 @@ export default function Home() {
     <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
       <h1 className="text-3xl font-bold">Meet in the Middle</h1>
       <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="First name"
+        className="border p-2 rounded w-48 text-center"
+      />
+      <input
         value={code}
         onChange={(e) => setCode(e.target.value)}
         placeholder="6-char room code"
@@ -36,7 +45,7 @@ export default function Home() {
       />
       <button
         onClick={enterRoom}
-        disabled={isLoading}
+        disabled={isLoading || !name.trim()}
         className="bg-blue-500 text-white px-4 py-2 rounded transition-colors transition-transform hover:bg-blue-600 active:scale-95 disabled:opacity-50"
       >
         {isLoading

--- a/tests/roomRoute.test.ts
+++ b/tests/roomRoute.test.ts
@@ -28,7 +28,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: 'select fail' });
@@ -73,7 +73,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: 'insert fail' });
@@ -118,7 +118,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: 'status fail' });
@@ -164,10 +164,12 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ roomId: '1', roomToken: 'token', code: 'abc' });
+    const data = await res.json();
+    expect(data).toMatchObject({ roomId: '1', roomToken: 'token', code: 'abc' });
+    expect(['your', 'their']).toContain(data.side);
     expect(signRoomToken).toHaveBeenCalledWith('1');
   });
 
@@ -214,10 +216,12 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ roomId: '1', roomToken: 'token', code: 'abc' });
+    const data = await res.json();
+    expect(data).toMatchObject({ roomId: '1', roomToken: 'token', code: 'abc' });
+    expect(['your', 'their']).toContain(data.side);
     expect(signRoomToken).toHaveBeenCalledWith('1');
   });
 });


### PR DESCRIPTION
## Summary
- gather participant name before entering room
- return an assigned side from `/api/room`
- store room token, side, and name in `localStorage`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb129dd34832ebc27a6a1c4e2d02b