### PR TITLE
Add name-based side assignment for rooms

### DIFF
--- a/app/api/room/route.ts
+++ b/app/api/room/route.ts
@@ -3,8 +3,18 @@ import { createAdminClient } from '@/lib/supabase';
 import { signRoomToken } from '@/lib/roomToken';
 import { randomBytes } from 'crypto';
 
+interface JoinRoomBody {
+  code?: string;
+  name: string;
+}
+
+interface NameChangePayload {
+  who: 'your' | 'their';
+  name: string;
+}
+
 export async function POST(req: NextRequest) {
-  const { code } = await req.json();
+  const { code, name }: JoinRoomBody = await req.json();
   const roomCode = (code || randomBytes(3).toString('hex')).toLowerCase();
   const adminClient = createAdminClient();
 
@@ -39,6 +49,48 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  const roomToken = signRoomToken(room.id);
-  return NextResponse.json({ roomId: room.id, roomToken, code: roomCode });
+  const { data: statusData, error: statusSelectError } = await adminClient
+    .from('status')
+    .select('your_name, their_name')
+    .eq('room_id', room.id)
+    .maybeSingle();
+  if (statusSelectError && statusSelectError.code !== 'PGRST116') {
+    console.error(statusSelectError);
+    return NextResponse.json({ error: statusSelectError.message }, { status: 500 });
+  }
+
+  const yourName = statusData?.your_name ?? null;
+  const theirName = statusData?.their_name ?? null;
+
+  let side: 'your' | 'their';
+  if (yourName === name) side = 'your';
+  else if (theirName === name) side = 'their';
+  else if (!yourName) side = 'your';
+  else side = 'their';
+
+  const { data: updatedStatus, error: upsertError } = await adminClient
+    .from('status')
+    .upsert(
+      { room_id: room.id, [`${side}_name`]: name },
+      { onConflict: 'room_id' }
+    )
+    .select('your_name, their_name')
+    .single();
+  if (upsertError) {
+    console.error(upsertError);
+    return NextResponse.json({ error: upsertError.message }, { status: 500 });
+  }
+
+  const payload = { who: side, name } satisfies NameChangePayload;
+  await adminClient
+    .channel(`room-${roomCode}`)
+    .send({ type: 'broadcast', event: 'NAME_CHANGE', payload });
+
+  const roomToken = signRoomToken(room.id, side, name);
+  return NextResponse.json({
+    side,
+    your_name: updatedStatus?.your_name ?? null,
+    their_name: updatedStatus?.their_name ?? null,
+    roomToken,
+  });
 }

--- a/lib/roomToken.ts
+++ b/lib/roomToken.ts
@@ -8,8 +8,14 @@ if (!secret) {
   );
 }
 
-export function signRoomToken(roomId: string): string {
-  return jwt.sign({ room_id: roomId }, secret!, { expiresIn: "7d" });
+export function signRoomToken(
+  roomId: string,
+  side: "your" | "their",
+  name: string
+): string {
+  return jwt.sign({ room_id: roomId, side, name }, secret!, {
+    expiresIn: "7d",
+  });
 }
 
 export function verifyRoomToken(token: string): string | null {

--- a/tests/roomRoute.test.ts
+++ b/tests/roomRoute.test.ts
@@ -28,7 +28,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: 'select fail' });
@@ -73,7 +73,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: 'insert fail' });
@@ -118,7 +118,7 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken: vi.fn() }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: 'status fail' });
@@ -153,10 +153,21 @@ describe.sequential('POST /api/room error handling', () => {
             if (table === 'status') {
               return {
                 insert: async () => ({ error: null }),
+                select: () => ({
+                  eq: () => ({
+                    maybeSingle: async () => ({ data: { your_name: null, their_name: null }, error: null }),
+                  }),
+                }),
+                upsert: () => ({
+                  select: () => ({
+                    single: async () => ({ data: { your_name: 'Alice', their_name: null }, error: null }),
+                  }),
+                }),
               };
             }
             throw new Error('unexpected table ' + table);
           },
+          channel: () => ({ send: vi.fn() }),
         }),
       };
     });
@@ -164,11 +175,16 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ roomId: '1', roomToken: 'token', code: 'abc' });
-    expect(signRoomToken).toHaveBeenCalledWith('1');
+    expect(await res.json()).toEqual({
+      side: 'your',
+      your_name: 'Alice',
+      their_name: null,
+      roomToken: 'token',
+    });
+    expect(signRoomToken).toHaveBeenCalledWith('1', 'your', 'Alice');
   });
 
   test('creates room when select returns PGRST116', async () => {
@@ -203,10 +219,21 @@ describe.sequential('POST /api/room error handling', () => {
             if (table === 'status') {
               return {
                 insert: async () => ({ error: null }),
+                select: () => ({
+                  eq: () => ({
+                    maybeSingle: async () => ({ data: { your_name: null, their_name: null }, error: null }),
+                  }),
+                }),
+                upsert: () => ({
+                  select: () => ({
+                    single: async () => ({ data: { your_name: 'Alice', their_name: null }, error: null }),
+                  }),
+                }),
               };
             }
             throw new Error('unexpected table ' + table);
           },
+          channel: () => ({ send: vi.fn() }),
         }),
       };
     });
@@ -214,10 +241,15 @@ describe.sequential('POST /api/room error handling', () => {
     vi.doMock('@/lib/roomToken', () => ({ signRoomToken }));
 
     const { POST } = await import('../app/api/room/route');
-    const req = { json: async () => ({ code: 'abc' }) } as unknown as NextRequest;
+    const req = { json: async () => ({ code: 'abc', name: 'Alice' }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ roomId: '1', roomToken: 'token', code: 'abc' });
-    expect(signRoomToken).toHaveBeenCalledWith('1');
+    expect(await res.json()).toEqual({
+      side: 'your',
+      your_name: 'Alice',
+      their_name: null,
+      roomToken: 'token',
+    });
+    expect(signRoomToken).toHaveBeenCalledWith('1', 'your', 'Alice');
   });
 });


### PR DESCRIPTION
## Summary
- allow joining a room with a display name and allocate caller to `your` or `their` slot based on name availability
- store the chosen name in the status table, sign tokens with side and name, and broadcast `NAME_CHANGE` events to room channels
- tighten TypeScript types for request parsing and broadcast payload

## Testing
- `pnpm test`
- `pnpm run lint`
- `pnpm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*


------
https://chatgpt.com/codex/tasks/task_e_68bdb12a7654832ea374deb0d0429d16