### PR TITLE
Display participant names in rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ create table status (
   room_id uuid references rooms(id) on delete cascade unique,
   your_ready boolean default false,
   their_ready boolean default false,
+  your_name text,
+  their_name text,
   updated_at timestamptz default now()
 );
 

--- a/lib/gemini.ts
+++ b/lib/gemini.ts
@@ -9,11 +9,16 @@ const schema = z.object({
 
 export type GeminiSummary = z.infer<typeof schema>;
 
-export async function callGemini(your: string, their: string): Promise<string> {
+export async function callGemini(
+  your: string,
+  their: string,
+  yourName = 'Your Side',
+  theirName = 'Their Side'
+): Promise<string> {
   const apiKey = process.env.GOOGLE_API_KEY;
   if (!apiKey) {
     return JSON.stringify({
-      summary: `Your Side: ${your}\nTheir Side: ${their}`,
+      summary: `${yourName}: ${your}\n${theirName}: ${their}`,
       nextSteps: [],
       toneNotes: '',
     });
@@ -109,7 +114,7 @@ Respond in JSON with keys "summary", "nextSteps", and "toneNotes".`;
     model: 'gemini-2.5-pro',
     systemInstruction: system,
   });
-  const user = `Your Side:\n${your}\n\nTheir Side:\n${their}`;
+  const user = `${yourName}:\n${your}\n\n${theirName}:\n${their}`;
   const result = await model.generateContent({
     contents: [{ role: 'user', parts: [{ text: user }] }],
     generationConfig: { responseMimeType: 'application/json' },

--- a/tests/generateRoute.test.ts
+++ b/tests/generateRoute.test.ts
@@ -29,6 +29,15 @@ describe('POST /api/generate', () => {
               }),
             };
           }
+          if (table === 'status') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  single: async () => ({ data: { your_name: 'Alice', their_name: 'Bob' }, error: null }),
+                }),
+              }),
+            };
+          }
           throw new Error('unexpected table ' + table);
         },
         channel: () => ({ send: vi.fn() }),


### PR DESCRIPTION
## Summary
- Store and document participant names in the `status` table schema.
- Show each participant's name in the room UI and update it in realtime.
- Pass participant names to Gemini so summaries label both sides correctly.

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb9d70c18832e9fd93b2d6f3f7dd4