### PR TITLE
Log verification errors for room tokens

### DIFF
--- a/lib/roomToken.ts
+++ b/lib/roomToken.ts
@@ -24,7 +24,8 @@ export function verifyRoomToken(token: string): string | null {
       room_id?: string;
     };
     return payload.room_id ?? null;
-  } catch {
+  } catch (err) {
+    console.error('verifyRoomToken failed:', err);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- log caught errors in `verifyRoomToken` for better diagnostics

## Testing
- `npm test`
- `npm run lint`
- `ROOM_JWT_SECRET=secret node -e "const r=require('./tmp/roomToken.js'); r.verifyRoomToken('bad');" 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_68bdc78efc5c832eb785d2dd8c419e42