### PR TITLE
Check room response before storing data

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,10 @@ export default function Home() {
         body: JSON.stringify({ code: roomCode, name }),
       });
       const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || 'Failed to enter room');
+        return;
+      }
       localStorage.setItem(`room-token-${roomCode}`, data.roomToken);
       localStorage.setItem(`room-side-${roomCode}`, data.side);
       if (name) localStorage.setItem(`room-name-${roomCode}`, name);


### PR DESCRIPTION
## Summary
- Verify `/api/room` response before storing tokens in localStorage
- Alert user and exit early when room entry fails

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68be046e9fdc832e9f7d029232a6c06c