### PR TITLE
Store and reload room summaries

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -62,6 +62,14 @@ export async function POST(req: NextRequest) {
       summary = parseGeminiResponse(text);
     }
 
+    const { error: summaryError } = await adminClient
+      .from("summaries")
+      .insert({ room_id: roomId, content: JSON.stringify(summary) });
+
+    if (summaryError) {
+      throw new Error(`Failed to save summary: ${summaryError.message}`);
+    }
+
     const { data: room } = await adminClient
       .from("rooms")
       .select("code")

--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -49,6 +49,14 @@ export default function RoomPage({ params }: { params: { code: string } }) {
           if (res.data.their_name) setTheirName(res.data.their_name);
         }
       });
+
+    fetch(`/api/history?roomToken=${token}&limit=1`)
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => {
+        if (Array.isArray(data) && data.length > 0) {
+          setSummary(data[0] as GeminiSummary);
+        }
+      });
     const channel = client
       .channel(`room-${code}`)
       .on('broadcast', { event: 'ENTRY_SUBMITTED' }, ({ payload }) => {

--- a/tests/generateRoute.test.ts
+++ b/tests/generateRoute.test.ts
@@ -38,6 +38,11 @@ describe('POST /api/generate', () => {
               }),
             };
           }
+          if (table === 'summaries') {
+            return {
+              insert: async () => ({ error: null }),
+            };
+          }
           throw new Error('unexpected table ' + table);
         },
         channel: () => ({ send: vi.fn() }),


### PR DESCRIPTION
## Summary
- persist generated summaries to `summaries` table
- retrieve latest summary for a room on load and reconnect
- adjust tests for new summaries insert

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0b6d9050832eaafc2300322606d4