### PR TITLE
Incorporate previous summaries into generate flow

### DIFF
--- a/tests/generateRoute.test.ts
+++ b/tests/generateRoute.test.ts
@@ -1,55 +1,111 @@
 import { describe, expect, test, vi } from 'vitest';
 import type { NextRequest } from 'next/server';
 
+type EntryRow = {
+  side: 'your' | 'their';
+  content: string;
+  created_at: string;
+};
+
+type SummaryRow = {
+  content: string;
+  created_at: string;
+};
+
+function setupSupabaseMock({
+  entriesData,
+  previousSummaryRows = [],
+  status = { your_name: 'Alice', their_name: 'Bob' },
+}: {
+  entriesData: EntryRow[];
+  previousSummaryRows?: SummaryRow[];
+  status?: { your_name: string; their_name: string };
+}) {
+  let currentEntries = [...entriesData];
+  const entriesOrderMock = vi.fn().mockImplementation(() =>
+    Promise.resolve({ data: currentEntries, error: null })
+  );
+  const entriesBuilder: any = {};
+  entriesBuilder.select = vi.fn(() => entriesBuilder);
+  entriesBuilder.eq = vi.fn(() => entriesBuilder);
+  entriesBuilder.gt = vi.fn((column: string, value: string) => {
+    currentEntries = currentEntries.filter((entry) => {
+      const entryValue = (entry as Record<string, string>)[column];
+      return entryValue > value;
+    });
+    return entriesBuilder;
+  });
+  entriesBuilder.order = entriesOrderMock;
+
+  const summaryOrderMock = vi.fn().mockResolvedValue({
+    data: previousSummaryRows,
+    error: null,
+  });
+  const summariesTable = {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        order: summaryOrderMock,
+      })),
+    })),
+    insert: vi.fn(async () => ({ error: null })),
+  };
+
+  const statusTable = {
+    select: () => ({
+      eq: () => ({
+        single: async () => ({ data: status, error: null }),
+      }),
+    }),
+  };
+
+  const roomsTable = {
+    select: () => ({
+      eq: () => ({
+        single: async () => ({ data: { code: 'abc' } }),
+      }),
+    }),
+  };
+
+  const adminClient = {
+    from: (table: string) => {
+      if (table === 'entries') {
+        return entriesBuilder;
+      }
+      if (table === 'summaries') {
+        return summariesTable;
+      }
+      if (table === 'status') {
+        return statusTable;
+      }
+      if (table === 'rooms') {
+        return roomsTable;
+      }
+      throw new Error('unexpected table ' + table);
+    },
+    channel: () => ({ send: vi.fn() }),
+  };
+
+  return {
+    adminClient,
+    entriesBuilder,
+    entriesOrderMock,
+    summariesTable,
+  };
+}
+
 describe('POST /api/generate', () => {
   test('returns summary when GOOGLE_API_KEY is missing', async () => {
     vi.resetModules();
     delete process.env.GOOGLE_API_KEY;
+    const supabase = setupSupabaseMock({
+      entriesData: [
+        { side: 'your', content: 'your perspective', created_at: '2024-01-01T00:00:00Z' },
+        { side: 'their', content: 'their perspective', created_at: '2024-01-01T00:01:00Z' },
+      ],
+    });
+
     vi.doMock('@/lib/supabase', () => ({
-      createAdminClient: () => ({
-        from: (table: string) => {
-          if (table === 'entries') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  order: async () => ({
-                    data: [
-                      { side: 'your', content: 'your perspective' },
-                      { side: 'their', content: 'their perspective' },
-                    ],
-                    error: null,
-                  }),
-                }),
-              }),
-            };
-          }
-          if (table === 'rooms') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  single: async () => ({ data: { code: 'abc' } }),
-                }),
-              }),
-            };
-          }
-          if (table === 'status') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  single: async () => ({ data: { your_name: 'Alice', their_name: 'Bob' }, error: null }),
-                }),
-              }),
-            };
-          }
-          if (table === 'summaries') {
-            return {
-              insert: async () => ({ error: null }),
-            };
-          }
-          throw new Error('unexpected table ' + table);
-        },
-        channel: () => ({ send: vi.fn() }),
-      }),
+      createAdminClient: () => supabase.adminClient,
     }));
     vi.doMock('@/lib/roomToken', () => ({ verifyRoomToken: () => 'room1' }));
 
@@ -64,18 +120,17 @@ describe('POST /api/generate', () => {
     expect(data.nextSteps).toEqual([]);
   });
 
-  test('uses the newest entries per side when generating the summary', async () => {
+  test('concatenates entries per side when generating the summary', async () => {
     vi.resetModules();
     process.env.GOOGLE_API_KEY = 'fake-key';
 
-    const orderMock = vi.fn().mockResolvedValue({
-      data: [
-        { side: 'your', content: 'latest from you' },
-        { side: 'your', content: 'older from you' },
-        { side: 'their', content: 'latest from them' },
-        { side: 'their', content: 'older from them' },
+    const supabase = setupSupabaseMock({
+      entriesData: [
+        { side: 'your', content: 'first from you', created_at: '2024-01-01T00:00:00Z' },
+        { side: 'their', content: 'first from them', created_at: '2024-01-01T00:01:00Z' },
+        { side: 'your', content: 'second from you', created_at: '2024-01-01T00:02:00Z' },
+        { side: 'their', content: 'second from them', created_at: '2024-01-01T00:03:00Z' },
       ],
-      error: null,
     });
 
     const callGemini = vi.fn().mockResolvedValue('gemini response');
@@ -91,47 +146,7 @@ describe('POST /api/generate', () => {
     }));
 
     vi.doMock('@/lib/supabase', () => ({
-      createAdminClient: () => ({
-        from: (table: string) => {
-          if (table === 'entries') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  order: orderMock,
-                }),
-              }),
-            };
-          }
-          if (table === 'rooms') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  single: async () => ({ data: { code: 'abc' } }),
-                }),
-              }),
-            };
-          }
-          if (table === 'status') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  single: async () => ({
-                    data: { your_name: 'Alice', their_name: 'Bob' },
-                    error: null,
-                  }),
-                }),
-              }),
-            };
-          }
-          if (table === 'summaries') {
-            return {
-              insert: async () => ({ error: null }),
-            };
-          }
-          throw new Error('unexpected table ' + table);
-        },
-        channel: () => ({ send: vi.fn() }),
-      }),
+      createAdminClient: () => supabase.adminClient,
     }));
 
     vi.doMock('@/lib/roomToken', () => ({ verifyRoomToken: () => 'room1' }));
@@ -143,17 +158,87 @@ describe('POST /api/generate', () => {
 
     const res = await POST(req);
     expect(res.status).toBe(200);
-    expect(orderMock).toHaveBeenCalledWith('created_at', { ascending: false });
+    expect(supabase.entriesOrderMock).toHaveBeenCalledWith('created_at', { ascending: true });
     expect(callGemini).toHaveBeenCalledWith(
-      'latest from you',
-      'latest from them',
+      'first from you\n\nsecond from you',
+      'first from them\n\nsecond from them',
       'Alice',
-      'Bob'
+      'Bob',
+      undefined
     );
     expect(parseGeminiResponse).toHaveBeenCalledWith('gemini response');
 
     const data = await res.json();
     expect(data).toEqual({ summary: 'parsed summary', nextSteps: ['step'], toneNotes: 'tone' });
+  });
+
+  test('passes the prior summary to Gemini when new entries are present', async () => {
+    vi.resetModules();
+    process.env.GOOGLE_API_KEY = 'fake-key';
+
+    const storedSummary = {
+      summary: 'We agreed to keep things calm and focus on listening.',
+      nextSteps: ['Schedule a weekly check-in'],
+      toneNotes: 'Respectful and warm tone',
+    };
+    const storedSummaryRow = {
+      content: JSON.stringify(storedSummary),
+      created_at: '2024-01-01T01:00:00Z',
+    };
+
+    const supabase = setupSupabaseMock({
+      entriesData: [
+        { side: 'your', content: 'earlier from you', created_at: '2024-01-01T00:30:00Z' },
+        { side: 'their', content: 'earlier from them', created_at: '2024-01-01T00:45:00Z' },
+        { side: 'your', content: 'update from you', created_at: '2024-01-01T01:05:00Z' },
+        { side: 'their', content: 'update from them', created_at: '2024-01-01T01:06:00Z' },
+      ],
+      previousSummaryRows: [storedSummaryRow],
+    });
+
+    const finalSummary = {
+      summary: 'parsed summary',
+      nextSteps: ['step'],
+      toneNotes: 'tone',
+    };
+
+    const callGemini = vi.fn().mockResolvedValue('gemini response');
+    const parseGeminiResponse = vi
+      .fn()
+      .mockImplementationOnce(() => storedSummary)
+      .mockImplementationOnce(() => finalSummary);
+
+    vi.doMock('@/lib/gemini', () => ({
+      callGemini,
+      parseGeminiResponse,
+    }));
+
+    vi.doMock('@/lib/supabase', () => ({
+      createAdminClient: () => supabase.adminClient,
+    }));
+
+    vi.doMock('@/lib/roomToken', () => ({ verifyRoomToken: () => 'room1' }));
+
+    const { POST } = await import('../app/api/generate/route');
+    const req = {
+      json: async () => ({ roomToken: 't' }),
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(parseGeminiResponse).toHaveBeenNthCalledWith(1, storedSummaryRow.content);
+    expect(supabase.entriesBuilder.gt).toHaveBeenCalledWith('created_at', storedSummaryRow.created_at);
+    expect(callGemini).toHaveBeenCalledWith(
+      'update from you',
+      'update from them',
+      'Alice',
+      'Bob',
+      storedSummary
+    );
+    expect(parseGeminiResponse).toHaveBeenLastCalledWith('gemini response');
+
+    const data = await res.json();
+    expect(data).toEqual(finalSummary);
   });
 });
 


### PR DESCRIPTION
## Summary
- query the latest stored summary before generating a new one, filter subsequent entries, and build complete transcripts per side
- allow the Gemini helper to prepend prior-summary context when calling the model and update tests for the new behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d02cea6908832ebedc43374c65d482